### PR TITLE
Don't give d2 to quote markers and conjunctions

### DIFF
--- a/kaichuo-alt.js
+++ b/kaichuo-alt.js
@@ -46,10 +46,8 @@ const MATRIX_SUBORDINATORS = ["ꝡa", "ma", "tıo"],
 
 const wordTones = new Map([
   ...[ ...PRONOUNS,
-       ...QUOTE_MARKERS,
        ...FOCUS_MARKERS,
        ...DETERMINERS,
-       ...CONJUNCTIONS,
        ...VOCATIVES,
        ...RISING_TONE_ILLOCUTIONS ]
      .map(w => [adorn(w, ''), d2]),


### PR DESCRIPTION
These can take the falling tone (and quote markers are verbs and take the falling tone by default), so it would be better to not give them the rising tone by default.