### PR TITLE
added support for the "ı" key in derani

### DIFF
--- a/kaichuo.js
+++ b/kaichuo.js
@@ -74,6 +74,7 @@ const deraniLayout = new Map([
   ["[", "󱛘"],
   ["]", "󱛙"],
   ["=", "󱛚"],
+  ["ı", "󱚹"]
 ]);
 
 const fallingDiphthongs = new Map([


### PR DESCRIPTION
it normally puts the correct derani character when you press the "i" key but it doesnt do the same thing for the "ı" key in turkish.